### PR TITLE
Fix Hands Minigame

### DIFF
--- a/minigames/games.py
+++ b/minigames/games.py
@@ -44,7 +44,7 @@ class HandsMinigame(GamblingMinigame, game="hands"):
             for j, y in enumerate(rolls):
                 if i == j:
                     continue
-                if (x + y) == result:
+                if (x + y) == bet:
                     return True
         return False
 


### PR DESCRIPTION
The hands minigame is currently broken: The win condition check currently checks whether the sum of two dice is equal to the _result_, not the _bet_.

The following screenshot shows the bug in action:
<img src="https://github.com/user-attachments/assets/8a754957-5621-4d4d-afb4-d1bb670f683a" width="150">

Note that you may also want to update the `BET_BIASED`. The theoretically best bet (using this fix) is 7 as I have verified with a short simulation.