### PR TITLE
report correct xp after modifiers

### DIFF
--- a/pilgram/classes.py
+++ b/pilgram/classes.py
@@ -448,16 +448,15 @@ class Player(CombatActor):
             self.xp -= req_xp
             req_xp = self.get_required_xp()
 
-    def add_xp(self, amount: float) -> bool:
-        """adds xp to the player and returns true if the player leveled up"""
+    def add_xp(self, amount: float) -> int:
+        """adds xp to the player & returns how much was actually added to the player"""
         amount *= self.cult.general_xp_mult
         if self.cult.xp_mult_per_player_in_cult != 1.0:
             amount *= self.cult.xp_mult_per_player_in_cult**self.cult.number_of_members
         self.xp += int(amount)
         if self.xp >= self.get_required_xp():
             self.level_up()
-            return True
-        return False
+        return int(amount)
 
     def add_money(self, amount: float) -> int:
         """adds money to the player & returns how much was actually added to the player"""

--- a/pilgram/manager.py
+++ b/pilgram/manager.py
@@ -184,7 +184,7 @@ class QuestManager(Manager):
                         Strings.tax_gain.format(amount=amount_am, name=player.name),
                     )
                     money -= amount
-            player.add_xp(xp)
+            xp_am = player.add_xp(xp)  # am = after modifiers
             money_am = player.add_money(money)  # am = after modifiers
             player.completed_quests += 1
             player.renown += renown
@@ -199,7 +199,7 @@ class QuestManager(Manager):
                 quest.success_text
                 + Strings.quest_success.format(name=quest.name)
                 + f"\n\n{Strings.quest_roll.format(roll=roll, target=value_to_beat)}"
-                + _gain(xp, money_am, renown, tax=tax)
+                + _gain(xp_am, money_am, renown, tax=tax)
                 + (Strings.piece_found if piece else ""),
             )
         else:
@@ -240,7 +240,7 @@ class QuestManager(Manager):
             ac.player.player_id
         )  # get the most up-to-date object
         xp, money = event.get_rewards(ac.player)
-        player.add_xp(xp)
+        xp_am = player.add_xp(xp)  # am = after modifiers
         money_am = player.add_money(money)  # am = after modifiers
         ac.player = player
         if player.hp_percent < 1.0:
@@ -249,7 +249,7 @@ class QuestManager(Manager):
             regeneration_text = ""
         self.db().update_player_data(player)
         self.db().update_quest_progress(ac)
-        text = f"*{event.event_text}*{_gain(xp, money_am, 0)}"
+        text = f"*{event.event_text}*{_gain(xp_am, money_am, 0)}"
         if ac.is_on_a_quest():
             if player.player_id in QTE_CACHE:
                 del QTE_CACHE[player.player_id]
@@ -342,14 +342,14 @@ class QuestManager(Manager):
             xp, money = enemy.get_rewards(player)
             renown = (enemy.get_level() + ac.quest.number + 1) * 10
             # add rewards
-            player.add_xp(xp)
+            xp_am = player.add_xp(xp)
             player.renown += renown
             money_am = player.add_money(money)
             # create notification text
             if isinstance(enemy, Enemy):
-                text += f"\n\n{enemy.meta.win_text}{_gain(xp, money_am, renown)}"
+                text += f"\n\n{enemy.meta.win_text}{_gain(xp_am, money_am, renown)}"
             else:
-                text += f"\n\n{Strings.shade_win}{_gain(xp, money_am, renown)}"
+                text += f"\n\n{Strings.shade_win}{_gain(xp_am, money_am, renown)}"
             # more rewards if combat was forced
             if ForcedCombat.is_set(player.flags) and (
                 random.random() <= 0.5

--- a/pilgram/spells.py
+++ b/pilgram/spells.py
@@ -50,8 +50,8 @@ def __add_to_spell_list(spell_short_name: str) -> Callable:
 def __midas_touch(caster: Player, args: list[str]) -> str:
     amount = 50 * caster.get_spell_charge()
     # we don't need to save the player data, it will be done automatically later
-    caster.add_money(amount)
-    return f"{amount} {MONEY} materialize in the air."
+    money_am = caster.add_money(amount)
+    return f"{money_am} {MONEY} materialize in the air."
 
 
 @__add_to_spell_list("bones")

--- a/pilgram/spells.py
+++ b/pilgram/spells.py
@@ -58,8 +58,8 @@ def __midas_touch(caster: Player, args: list[str]) -> str:
 def __bone_recall(caster: Player, args: list[str]) -> str:
     amount = 50 * caster.get_spell_charge()
     # we don't need to save the player data, it will be done automatically later
-    caster.add_xp(amount)
-    return f"You gain {amount} xp from the wisdom of the dead."
+    xp_am = caster.add_xp(amount)
+    return f"You gain {xp_am} xp from the wisdom of the dead."
 
 
 @__add_to_spell_list("displacement")

--- a/ui/functions.py
+++ b/ui/functions.py
@@ -783,14 +783,14 @@ def minigame_process(context: UserContext, user_input: str) -> str:
         player: Player = minigame.player
         xp, money = minigame.get_rewards_apply_bonuses()
         if minigame.won:
-            player.add_money(money)
+            money_am = player.add_money(money)
             if xp > 0:
-                player.add_xp(xp),
-                message += f"\n\nYou gain {xp} xp & {money} {MONEY}."
+                xp_am = player.add_xp(xp),
+                message += f"\n\nYou gain {xp_am} xp & {money_am} {MONEY}."
             else:
                 items = db().get_player_items(player.player_id)
                 item = Equipment.generate(player.level, EquipmentType.get_random(), random.choice((0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 3)))
-                message += f"\n\nYou gain {money} {MONEY} & find *{item.name}*."
+                message += f"\n\nYou gain {money_am} {MONEY} & find *{item.name}*."
                 if len(items) >= player.get_inventory_size():
                     message += " You leave the item there since you don't have space in your inventory."
                 else:
@@ -804,9 +804,9 @@ def minigame_process(context: UserContext, user_input: str) -> str:
                 guild.tourney_score += minigame.RENOWN
                 db().update_guild(guild)
             return message + ("" if minigame.RENOWN == 0 else f"\n\nYou gain {minigame.RENOWN} renown.")
-        player.add_xp(xp)
+        xp_am = player.add_xp(xp)
         db().update_player_data(minigame.player)
-        return message + f"\n\n{Strings.xp_gain.format(xp=xp)}"
+        return message + f"\n\n{Strings.xp_gain.format(xp=xp_am)}"
     return message
 
 


### PR DESCRIPTION
tried to fix all(?) places where xp is added to report the correct amount to the player after modifiers are applied.

replaced the bool levelup return from add_xp since it seemed to be unused.